### PR TITLE
REVISION#1: Adding SQL Standard Changes for BMP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ nbproject
 ._*
 Thumbs.db
 Gemfile.lock
+CNAME
 
 _site
 _gh_pages

--- a/_includes/sqlstyle.guide.md
+++ b/_includes/sqlstyle.guide.md
@@ -105,18 +105,21 @@ FROM staff AS s;
 * The name must contain a verb.
 * Do not prefix with `sp_` or any other such descriptive prefix or Hungarian
   notation.
-* Prefix arguments/variables with an underscore.
-* Align argument types with longest argument name + 1 space.
+* Prefix arguments/variables with an underscore. This is done to visually
+  differentiate variables from other identifiers such as column and table
+  names.
+* Align argument types with longest argument name + 1 space in order to 
+  create a separate visual column for the type declarations.
 * All IN parameters should be listed before OUT parameters.
-* Arguments/variables meant to be immutable are screaming snake caps.
-* Arguments/variables meant to be mutable are lowercase snake caps.
+* Arguments/variables meant to be immutable should be in screaming snake case.
+* Arguments/variables meant to be mutable should be in lowercase snake case.
 * Default to immutable naming conventions.
 
 ```sql
 CREATE PROCEDURE `test`(
   IN
   _LKP_ID            INT,  -- not supposed to change this, even though you can!
-  _lkp_id_id2        INT,  -- you can change this
+  _lkp_id_id2        INT,  -- you can change this  but changing input values is discouraged
   OUT _something_id  INT,
   OUT _something_id2 INT,
   OUT _something_id3 INT
@@ -124,11 +127,15 @@ CREATE PROCEDURE `test`(
 
 BEGIN
 
-DECLARE _SOMETHING_ID VARCHAR(255) DEFAULT '123'; -- allowed
-SET _SOMETHING_ID = '123'; -- not allowed
+DECLARE _CNST_HIDDEN_COMPONENT VARCHAR(255) DEFAULT 'Hidden Component'; -- allowed
+SET _CNST_HIDDEN_COMPONENT = 'Hidden Component'; -- not allowed
 
-DECLARE _some_other_name VARCHAR(255); 
-SET _some_other_name = 'Frank Rizzo'; -- allowed
+DECLARE _code_name VARCHAR(255); 
+
+SELECT `name`
+INTO _code_name -- allowed
+FROM codes
+WHERE id = _LKP_ID;
 ```
 
 
@@ -239,12 +246,21 @@ Always include newlines/vertical space:
 * before `AND` or `OR`
 * after semicolons to separate queries for easier reading
 * after each keyword definition
-* to separate code into related sections, which helps to ease the readability of
-  large chunks of code.
+* to separate code into related sections, which helps to ease the readability
+  of large chunks of code.
 
-Keeping the top most dependent keywords (e.g. `ON` depends on `JOIN`, `AND` depends on `WHERE`,
-`SET` depends on `UPDATE`) left aligned with the subsequent dependent keywords indented 2 spaces helps make it clear
-all the lines are part of the same clause.
+Additionally, for the following pairs of dependent key words - `ON` depends
+on `JOIN`/`LEFT JOIN`/`RIGHT JOIN`, `AND`/`OR` depends on `WHERE`, `SET`
+depends on `UPDATE`, `VALUES` depends on `INSERT INTO`:
+* `JOIN`/`LEFT JOIN`/`RIGHT JOIN` are left defined relative to `FROM` with
+  `ON` being on the same line when there is a single join condition or `ON`
+  being on the next line indented 2 spaces, with the additional `AND`/`OR`
+  conditions each on a new line indented 2 spaces, left aligned with `ON`.
+* `WHERE` is left defined relative to `SELECT` with subsequent `AND`/`OR`
+  each on their own line indented 2 spaces.
+* `UPDATE` is left defined with `SET` on a newline indented 2 spaces.
+* `INSERT INTO` is left defined with `VALUES` being left defined too.
+
 
 ```sql
 INSERT INTO albums (title, release_date, recording_date)
@@ -260,20 +276,24 @@ WHERE title = 'The New Danger';
 
 ```sql
 SELECT
-  a.title,
-  a.release_date,
-  a.recording_date,
-  a.production_date
-FROM albums AS a
+  artists.name,
+  albums.title,
+  albums.release_date,
+  albums.recording_date,
+  albums.production_date
+FROM albums AS albums
+LEFT JOIN artists AS artists
+  ON albums.artist_id = artists.id
+  AND artists.group_count > 2
 WHERE a.title = 'Charcoal Lane'
-   OR a.title = 'The New Danger';
+  OR a.title = 'The New Danger';
 ```
 
 #### JOINs
 
-Joins should be left defined and in alignment with the `FROM` keyword
+Joins should be directly underneath the FROM keyword with no indentation.
 
-Single line `JOIN`s are fine for simple situations
+Single line `JOIN`s are fine for simple situations.
 
 ```sql
 SELECT r.last_name

--- a/_includes/sqlstyle.guide.md
+++ b/_includes/sqlstyle.guide.md
@@ -93,8 +93,7 @@ FROM staff;
 ```sql
 SELECT first_name AS fn
 FROM staff AS s1
-  JOIN students AS s2
-    ON s2.mentor_id = s1.staff_num;
+JOIN students AS s2 ON s2.mentor_id = s1.staff_num;
 ```
 ```sql
 SELECT SUM(s.monitor_tally) AS monitor_total
@@ -106,6 +105,32 @@ FROM staff AS s;
 * The name must contain a verb.
 * Do not prefix with `sp_` or any other such descriptive prefix or Hungarian
   notation.
+* Prefix arguments/variables with an underscore.
+* Align argument types with longest argument name + 1 space.
+* All IN parameters should be listed before OUT parameters.
+* Arguments/variables meant to be immutable are screaming snake caps.
+* Arguments/variables meant to be mutable are lowercase snake caps.
+* Default to immutable naming conventions.
+
+```sql
+CREATE PROCEDURE `test`(
+  IN
+  _LKP_ID            INT,  -- not supposed to change this, even though you can!
+  _lkp_id_id2        INT,  -- you can change this
+  OUT _something_id  INT,
+  OUT _something_id2 INT,
+  OUT _something_id3 INT
+)
+
+BEGIN
+
+DECLARE _SOMETHING_ID VARCHAR(255) DEFAULT '123'; -- allowed
+SET _SOMETHING_ID = '123'; -- not allowed
+
+DECLARE _some_other_name VARCHAR(255); 
+SET _some_other_name = 'Frank Rizzo'; -- allowed
+```
+
 
 ### Uniform prefixes
 
@@ -217,8 +242,8 @@ Always include newlines/vertical space:
 * to separate code into related sections, which helps to ease the readability of
   large chunks of code.
 
-Keeping all the dependent keywords (e.g. `ON` depends on `JOIN`, `AND` depends on `WHERE`,
-`SET` depends on `UPDATE` right aligned with the top level keywords helps make it clear
+Keeping the top most dependent keywords (e.g. `ON` depends on `JOIN`, `AND` depends on `WHERE`,
+`SET` depends on `UPDATE`) left aligned with the subsequent dependent keywords indented 2 spaces helps make it clear
 all the lines are part of the same clause.
 
 ```sql
@@ -229,7 +254,7 @@ VALUES ('Charcoal Lane', '1990-01-01 01:01:01.00000', '1990-01-01 01:01:01.00000
 
 ```sql
 UPDATE albums
-   SET release_date = '1990-01-01 01:01:01.00000'
+SET release_date = '1990-01-01 01:01:01.00000'
 WHERE title = 'The New Danger';
 ```
 
@@ -246,27 +271,34 @@ WHERE a.title = 'Charcoal Lane'
 
 #### JOINs
 
-Joins should be indented 2 spaces right from the `FROM` keyword
+Joins should be left defined relative to the `FROM` keyword
 
 Single line `JOIN`s are fine for simple situations
 
 ```sql
 SELECT r.last_name
 FROM riders AS r
-  INNER JOIN bikes AS b ON r.bike_vin_num = b.vin_num
-  INNER JOIN crew AS c ON r.crew_chief_last_name = c.last_name
+INNER JOIN bikes AS b ON r.bike_vin_num = b.vin_num
+INNER JOIN crew AS c ON r.crew_chief_last_name = c.last_name;
 ```
 
 Multi line JOINs should be indented as per the dependent keywords rule:
 
 ```sql
-SELECT r.last_name
+SELECT 
+  r.last_name,
+  r.first_name,
+  b.model_num,
+  b.make_year,
+  CONCAT(c.first_name, ' ', c.last_name) AS  `Crew Chief`
 FROM riders AS r
-  INNER JOIN bikes AS b
-          ON r.bike_vin_num = b.vin_num
-         AND r.bike_lane = r.lane
-  INNER JOIN crew c ON r.crew_chief_last_name = c.last_name
-WHERE id = 5
+INNER JOIN bikes AS b
+  ON r.bike_vin_num = b.vin_num
+  AND r.bike_lane = r.lane
+INNER JOIN crew c ON r.crew_chief_last_name = c.last_name
+WHERE b.make_year > 2010
+  AND b.vin_num LIKE "%NRG%"
+  ORDER BY b.make_year DESC;
 ```
 
 #### Boolean Expressions
@@ -307,7 +339,7 @@ Indent them until the closing parentheses.
 WITH my_tmp_table AS (
   SELECT r.last_name
   FROM riders AS r
-    INNER JOIN bikes AS b ON r.bike_vin_num = b.vin_num
+  INNER JOIN bikes AS b ON r.bike_vin_num = b.vin_num
   WHERE id = 10
 ),
 
@@ -318,7 +350,7 @@ my_other_tmp_table AS (
 
 SELECT *
 FROM my_tmp_table
-  JOIN my_other_tmp_table ON my_other_tmp_table.last_name = my_tmp_table.last_name
+JOIN my_other_tmp_table ON my_other_tmp_table.last_name =    my_tmp_table.last_name
 ```
 
 #### Sub-queries
@@ -346,7 +378,7 @@ WHERE r.last_name IN
     FROM champions AS c
     WHERE YEAR(championship_date) > '2008'
       AND c.confirmed = 'Y'
-  )
+  );
 ```
 
 #### Case statements (PostreSQL)
@@ -380,7 +412,7 @@ SELECT
     END AS city,
   street_address,
   phone_number
-FROM office_locations
+FROM office_locations;
 ```
 
 #### Case statements (MySql)
@@ -392,7 +424,7 @@ SELECT
       THEN 'Brighton'
     WHEN 'EH1'
       THEN 'Edinburgh'
-    END AS city,
+  END AS city,
   street_address,
   phone_number
 FROM office_locations
@@ -416,11 +448,11 @@ SELECT
       THEN 'Brighton'
     WHEN 'EH1'
       THEN 'Edinburgh'
-    END AS city
+  END AS city
 FROM office_locations
 WHERE country = 'United Kingdom'
   AND opening_time BETWEEN 8 AND 9
-  AND postcode IN ('EH1', 'BN1', 'NN1', 'KW1')
+  AND postcode IN ('EH1', 'BN1', 'NN1', 'KW1');
 ```
 
 ## Create syntax

--- a/_includes/sqlstyle.guide.md
+++ b/_includes/sqlstyle.guide.md
@@ -254,7 +254,7 @@ VALUES ('Charcoal Lane', '1990-01-01 01:01:01.00000', '1990-01-01 01:01:01.00000
 
 ```sql
 UPDATE albums
-SET release_date = '1990-01-01 01:01:01.00000'
+  SET release_date = '1990-01-01 01:01:01.00000'
 WHERE title = 'The New Danger';
 ```
 

--- a/_includes/sqlstyle.guide.md
+++ b/_includes/sqlstyle.guide.md
@@ -298,7 +298,7 @@ INNER JOIN bikes AS b
 INNER JOIN crew c ON r.crew_chief_last_name = c.last_name
 WHERE b.make_year > 2010
   AND b.vin_num LIKE "%NRG%"
-  ORDER BY b.make_year DESC;
+ORDER BY b.make_year DESC;
 ```
 
 #### Boolean Expressions
@@ -390,9 +390,9 @@ SELECT CASE WHEN x > y THEN 1 ELSE 0 END
 FROM table
 ```
 
-Or WHEN/END should have 2 space left justification, and `WHEN`/`THEN` should be indented the same as the `ELSE`/`value`.
+Or WHEN should have 2 space left justification, and `WHEN`/`THEN` should be indented the same as the `ELSE`/`value`.
 Multiple `AND` or `OR` clauses can be inlined if < 80 characters, or should be right aligned with the whitespace river
-after `WHEN` if they are longer
+after `WHEN` if they are longer. `END` should be inline with the initial `CASE` keyword.
 
 ```sql
 SELECT
@@ -409,7 +409,7 @@ SELECT
       THEN 'something else'
     ELSE
       'x and y not related'
-    END AS city,
+  END AS city,
   street_address,
   phone_number
 FROM office_locations;

--- a/_includes/sqlstyle.guide.md
+++ b/_includes/sqlstyle.guide.md
@@ -350,7 +350,7 @@ my_other_tmp_table AS (
 
 SELECT *
 FROM my_tmp_table
-JOIN my_other_tmp_table ON my_other_tmp_table.last_name =    my_tmp_table.last_name
+JOIN my_other_tmp_table ON my_other_tmp_table.last_name = my_tmp_table.last_name
 ```
 
 #### Sub-queries

--- a/_includes/sqlstyle.guide.md
+++ b/_includes/sqlstyle.guide.md
@@ -402,7 +402,7 @@ SELECT
     WHEN x > y AND x > z
       THEN 'x more than y and more than z'
     WHEN some_very_long_thing_happened BETWEEN '2016-01-01' AND '2016-01-01'
-     AND some_event_very_much_longer_thing_happened BETWEEN '2016-01-01' AND '2016-01-01'
+      AND some_event_very_much_longer_thing_happened BETWEEN '2016-01-01' AND '2016-01-01'
       THEN 'something happened later'
     WHEN some_very_long_thing_happened BETWEEN '2016-01-01' AND '2016-01-01'
       OR some_event_very_much_longer_thing_happened BETWEEN '2016-01-01' AND '2016-01-01'

--- a/_includes/sqlstyle.guide.md
+++ b/_includes/sqlstyle.guide.md
@@ -478,9 +478,7 @@ WHERE country = 'United Kingdom'
 * Use `TRUE` and `FALSE` instead of `0` and `1` as that it is immediately
   obvious that these values are booleans and not magic numbers. This is also
   more semantic. It appears as though SQL99 introduces this "IS FALSE" or "IS
-  TRUE" syntax. Since this style guide already suggests following the
-  standards where possible, we should here as well. Note that TRUE and FALSE 
-  are reserved words.
+  TRUE" syntax. Note that TRUE and FALSE are reserved words.
 
 ```sql
 SELECT count(*)

--- a/_includes/sqlstyle.guide.md
+++ b/_includes/sqlstyle.guide.md
@@ -403,7 +403,7 @@ WHERE r.last_name IN
 
 #### Case statements (PostreSQL)
 
-`CASE` and `END` can either be inline if they are less than 80 characters:
+`CASE` and `END` can either be inline if they are up to 100 characters:
 
 ```sql
 SELECT CASE WHEN x > y THEN 1 ELSE 0 END
@@ -473,6 +473,19 @@ FROM office_locations
 WHERE country = 'United Kingdom'
   AND opening_time BETWEEN 8 AND 9
   AND postcode IN ('EH1', 'BN1', 'NN1', 'KW1');
+```
+
+* Use `TRUE` and `FALSE` instead of `0` and `1` as that it is immediately
+  obvious that these values are booleans and not magic numbers. This is also
+  more semantic. It appears as though SQL99 introduces this "IS FALSE" or "IS
+  TRUE" syntax. Since this style guide already suggests following the
+  standards where possible, we should here as well. Note that TRUE and FALSE 
+  are reserved words.
+
+```sql
+SELECT count(*)
+FROM office_locations
+WHERE is_shared IS FALSE;
 ```
 
 ## Create syntax

--- a/_includes/sqlstyle.guide.md
+++ b/_includes/sqlstyle.guide.md
@@ -271,7 +271,7 @@ WHERE a.title = 'Charcoal Lane'
 
 #### JOINs
 
-Joins should be left defined relative to the `FROM` keyword
+Joins should be left defined and in alignment with the `FROM` keyword
 
 Single line `JOIN`s are fine for simple situations
 

--- a/_site/CNAME
+++ b/_site/CNAME
@@ -1,1 +1,1 @@
-www.my.sqlstyle.guide
+www.mysqlstyle.guide

--- a/_site/CNAME
+++ b/_site/CNAME
@@ -1,1 +1,1 @@
-www.sqlstyle.guide
+www.mysqlstyle.guide

--- a/_site/CNAME
+++ b/_site/CNAME
@@ -1,0 +1,1 @@
+www.my.sqlstyle.guide

--- a/_site/CNAME
+++ b/_site/CNAME
@@ -1,1 +1,1 @@
-www.mysqlstyle.guide
+www.sqlstyle.guide


### PR DESCRIPTION
In this pull request, I am presenting changes to the base SQL Style Guide to conform to the standards discussed. My edits pertain to stored procedure creation syntax, in particular, how we treat in/out params and local vars, and indentation rules for SQL keywords and reserved words. Additionally, I added semicolons in queries to further indicate that this is for a MySQL dev environment.